### PR TITLE
Fix grep for registry pod in e2e

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/golang/glog"
 
@@ -58,7 +58,7 @@ func walkJSONFiles(inDir string, fn func(name, path string, data []byte)) error 
 func TestExampleObjectSchemas(t *testing.T) {
 	// Allow privileged containers
 	// TODO: make this configurable and not the default https://github.com/openshift/origin/issues/662
-	kubelet.SetupCapabilities(true, nil)
+	capabilities.Setup(true, nil)
 	cases := map[string]map[string]runtime.Object{
 		"../examples/hello-openshift": {
 			"hello-pod":     &kapi.Pod{},

--- a/hack/conversion/conversion.go
+++ b/hack/conversion/conversion.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/golang/glog"
+	flag "github.com/spf13/pflag"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+
+	//"github.com/openshift/origin/pkg/api"
+	_ "github.com/openshift/origin/pkg/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/api/v1beta3"
+)
+
+var (
+	functionDest = flag.StringP("funcDest", "f", "-", "Output for conversion functions; '-' means stdout")
+	namesDest    = flag.StringP("nameDest", "n", "-", "Output for function names; '-' means stdout")
+	version      = flag.StringP("version", "v", "v1beta3", "Version for conversion.")
+)
+
+func main() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	flag.Parse()
+
+	var funcOut io.Writer
+	if *functionDest == "-" {
+		funcOut = os.Stdout
+	} else {
+		file, err := os.Create(*functionDest)
+		if err != nil {
+			glog.Fatalf("Couldn't open %v: %v", *functionDest, err)
+		}
+		defer file.Close()
+		funcOut = file
+	}
+	var nameOut io.Writer
+	if *namesDest == "-" {
+		nameOut = os.Stdout
+	} else {
+		file, err := os.Create(*namesDest)
+		if err != nil {
+			glog.Fatalf("Couldn't open %v: %v", *functionDest, err)
+		}
+		defer file.Close()
+		nameOut = file
+	}
+
+	generator := conversion.NewGenerator(kapi.Scheme.Raw())
+	// TODO(wojtek-t): Change the overwrites to a flag.
+	generator.OverwritePackage(*version, "")
+	generator.OverwritePackage("api", "newer")
+	for _, knownType := range kapi.Scheme.KnownTypes(*version) {
+		if strings.Contains(knownType.PkgPath(), "GoogleCloudPlatform/kubernetes") {
+			continue
+		}
+		if err := generator.GenerateConversionsForType(*version, knownType); err != nil {
+			glog.Errorf("error while generating conversion functions for %v: %v", knownType, err)
+		}
+	}
+	if err := generator.WriteConversionFunctions(funcOut); err != nil {
+		glog.Fatalf("Error while writing conversion functions: %v", err)
+	}
+	if err := generator.WriteConversionFunctionNames(nameOut); err != nil {
+		glog.Fatalf("Error while writing conversion functions: %v", err)
+	}
+}

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -355,7 +355,7 @@ validate_response "-s -k --resolve www.example.com:443:${CONTAINER_ACCESSIBLE_AP
 
 # Remote command execution
 echo "[INFO] Validating exec"
-registry_pod=$(osc get pod | grep docker-registry | awk '{print $1}')
+registry_pod=$(osc get pod | grep deployment=docker-registry | grep docker-registry | awk '{print $1}')
 osc exec -p ${registry_pod} whoami | grep root
 
 # Port forwarding

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -40,7 +40,7 @@ func ValidateObject(obj runtime.Object) (errors []error) {
 	case *kapi.Namespace:
 		errors = validation.ValidateNamespace(t)
 	case *kapi.Node:
-		errors = validation.ValidateMinion(t)
+		errors = validation.ValidateNode(t)
 
 	case *imageapi.Image:
 		t.Namespace = ""

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -19,8 +19,6 @@ func init() {
 		&RoleBindingList{},
 		&RoleList{},
 
-		&IsPersonalSubjectAccessReview{},
-
 		&ClusterRole{},
 		&ClusterRoleBinding{},
 		&ClusterPolicy{},
@@ -53,5 +51,3 @@ func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
 func (*RoleBindingList) IsAnAPIObject()              {}
 func (*RoleList) IsAnAPIObject()                     {}
-
-func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -77,7 +77,7 @@ type PolicyRule struct {
 	Verbs kutil.StringSet
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
-	AttributeRestrictions kruntime.EmbeddedObject
+	AttributeRestrictions
 	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
 	Resources kutil.StringSet
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
@@ -87,9 +87,9 @@ type PolicyRule struct {
 	NonResourceURLs kutil.StringSet
 }
 
-// IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
-type IsPersonalSubjectAccessReview struct {
-	kapi.TypeMeta
+type AttributeRestrictions struct {
+	// Indicates this is a personal subject access review
+	IsPersonalSubjectAccessReview bool
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -19,8 +19,6 @@ func init() {
 		&RoleBindingList{},
 		&RoleList{},
 
-		&IsPersonalSubjectAccessReview{},
-
 		&ClusterRole{},
 		&ClusterRoleBinding{},
 		&ClusterPolicy{},
@@ -53,5 +51,3 @@ func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
 func (*RoleBindingList) IsAnAPIObject()              {}
 func (*RoleList) IsAnAPIObject()                     {}
-
-func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -20,7 +20,7 @@ type PolicyRule struct {
 	Verbs []string `json:"verbs"`
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
-	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions,omitempty"`
+	AttributeRestrictions `json:"attributeRestrictions,omitempty"`
 	// ResourceKinds is a list of resources this rule applies to.  ResourceAll represents all resources.
 	// DEPRECATED
 	ResourceKinds []string `json:"resourceKinds,omitempty"`
@@ -33,10 +33,13 @@ type PolicyRule struct {
 	NonResourceURLsSlice []string `json:"nonResourceURLs,omitempty"`
 }
 
-// IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
-type IsPersonalSubjectAccessReview struct {
-	kapi.TypeMeta `json:",inline"`
+type AttributeRestrictions struct {
+	// Indicates this is a personal subject access review
+	IsPersonalSubjectAccessReview bool `json:"isPersonalSubjectAccessReview,omitempty"`
 }
+
+// IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
+type IsPersonalSubjectAccessReview struct{}
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
 type Role struct {

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -19,8 +19,6 @@ func init() {
 		&RoleBindingList{},
 		&RoleList{},
 
-		&IsPersonalSubjectAccessReview{},
-
 		&ClusterRole{},
 		&ClusterRoleBinding{},
 		&ClusterPolicy{},
@@ -53,5 +51,3 @@ func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
 func (*RoleBindingList) IsAnAPIObject()              {}
 func (*RoleList) IsAnAPIObject()                     {}
-
-func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -20,7 +20,7 @@ type PolicyRule struct {
 	Verbs []string `json:"verbs"`
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
-	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions,omitempty"`
+	AttributeRestrictions `json:"attributeRestrictions,omitempty"`
 	// ResourceKinds is a list of resources this rule applies to.  ResourceAll represents all resources.
 	// DEPRECATED
 	ResourceKinds []string `json:"resourceKinds,omitempty"`
@@ -33,9 +33,9 @@ type PolicyRule struct {
 	NonResourceURLsSlice []string `json:"nonResourceURLs,omitempty"`
 }
 
-// IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
-type IsPersonalSubjectAccessReview struct {
-	kapi.TypeMeta `json:",inline"`
+type AttributeRestrictions struct {
+	// Indicates this is a personal subject access review
+	IsPersonalSubjectAccessReview bool `json:"isPersonalSubjectAccessReview,omitempty"`
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.

--- a/pkg/authorization/authorizer/attributes.go
+++ b/pkg/authorization/authorizer/attributes.go
@@ -1,7 +1,6 @@
 package authorizer
 
 import (
-	"fmt"
 	"path"
 	"strings"
 
@@ -37,13 +36,9 @@ func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.Policy
 		if a.resourceMatches(allowedResourceTypes) {
 			if a.nameMatches(rule.ResourceNames) {
 				// this rule matches the request, so we should check the additional restrictions to be sure that it's allowed
-				if rule.AttributeRestrictions.Object != nil {
-					switch rule.AttributeRestrictions.Object.(type) {
-					case (*authorizationapi.IsPersonalSubjectAccessReview):
-						return IsPersonalAccessReview(a)
-					default:
-						return false, fmt.Errorf("unable to interpret: %#v", rule.AttributeRestrictions.Object)
-					}
+				switch restrict := rule.AttributeRestrictions; {
+				case restrict.IsPersonalSubjectAccessReview:
+					return IsPersonalAccessReview(a)
 				}
 
 				return true, nil

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -5,7 +5,6 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -13,23 +12,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
-func TestInvalidRole(t *testing.T) {
-	test := &authorizeTest{
-		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Brad"}),
-		attributes: &DefaultAuthorizationAttributes{
-			Verb:     "get",
-			Resource: "buildConfigs",
-		},
-		expectedAllowed: false,
-		expectedError:   "unable to interpret:",
-	}
-	test.policies = newDefaultGlobalPolicies()
-	test.policies = append(test.policies, newInvalidExtensionPolicies()...)
-	test.bindings = newDefaultGlobalBinding()
-	test.bindings = append(test.bindings, newInvalidExtensionBindings()...)
-
-	test.test(t)
-}
 func TestInvalidRoleButRuleNotUsed(t *testing.T) {
 	test := &authorizeTest{
 		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Brad"}),
@@ -506,11 +488,11 @@ func newInvalidExtensionPolicies() []authorizationapi.Policy {
 						Namespace: "mallet",
 					},
 					Rules: []authorizationapi.PolicyRule{
-						{
-							Verbs:                 util.NewStringSet("watch", "list", "get"),
-							Resources:             util.NewStringSet("buildConfigs"),
-							AttributeRestrictions: runtime.EmbeddedObject{&authorizationapi.Role{}},
-						},
+						/*{
+							Verbs:     util.NewStringSet("watch", "list", "get"),
+							Resources: util.NewStringSet("buildConfigs"),
+							// TODO: there is no invalid combination here yet
+						},*/
 						{
 							Verbs:     util.NewStringSet("update"),
 							Resources: util.NewStringSet("buildConfigs"),

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -297,7 +297,7 @@ func (c ControllerClient) CreatePod(namespace string, pod *kapi.Pod) (*kapi.Pod,
 
 // DeletePod destroys a pod using the Kubernetes client.
 func (c ControllerClient) DeletePod(namespace string, pod *kapi.Pod) error {
-	return c.KubeClient.Pods(namespace).Delete(pod.Name)
+	return c.KubeClient.Pods(namespace).Delete(pod.Name, nil)
 }
 
 // GetImageStream retrieves an image repository by namespace and name

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -119,7 +119,7 @@ func mockCustomBuild() *buildapi.Build {
 						Name: "builder-image",
 					},
 					Env: []kapi.EnvVar{
-						{"FOO", "BAR"},
+						{Name: "FOO", Value: "BAR"},
 					},
 					ExposeDockerSocket: true,
 				},

--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -143,8 +143,8 @@ func (r *REST) waitForBuild(ctx kapi.Context, build *api.Build) error {
 }
 
 // NewGetOptions returns a new options object for build logs
-func (r *REST) NewGetOptions() runtime.Object {
-	return &api.BuildLogOptions{}
+func (r *REST) NewGetOptions() (runtime.Object, bool, string) {
+	return &api.BuildLogOptions{}, false, ""
 }
 
 // New creates an empty BuildLog resource

--- a/pkg/build/registry/etcd/etcd_test.go
+++ b/pkg/build/registry/etcd/etcd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -21,7 +22,7 @@ import (
 )
 
 func NewTestEtcd(client tools.EtcdClient) *Etcd {
-	return New(tools.NewEtcdHelper(client, latest.Codec))
+	return New(tools.NewEtcdHelper(client, latest.Codec, etcdtest.PathPrefix()))
 }
 
 // This copy and paste is not pure ignorance.  This is that we can be sure that the key is getting made as we

--- a/pkg/cmd/cli/cmd/edit.go
+++ b/pkg/cmd/cli/cmd/edit.go
@@ -126,7 +126,7 @@ func RunEdit(fullName string, f *clientcmd.Factory, out io.Writer, cmd *cobra.Co
 	defaultVersion := cmdutil.OutputVersion(cmd, clientConfig.Version)
 	results := editResults{}
 	for {
-		obj, err := resource.AsVersionedObject(infos, defaultVersion)
+		obj, err := resource.AsVersionedObject(infos, false, defaultVersion)
 		if err != nil {
 			return preservedFile(err, results.file, cmd.Out())
 		}

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -144,7 +144,10 @@ func RunNewApplication(f *clientcmd.Factory, out io.Writer, c *cobra.Command, ar
 
 	label := cmdutil.GetFlagString(c, "labels")
 	if len(label) != 0 {
-		lbl := ctl.ParseLabels(label)
+		lbl, err := ctl.ParseLabels(label)
+		if err != nil {
+			return err
+		}
 		for _, object := range result.List.Items {
 			err = util.AddObjectLabels(object, lbl)
 			if err != nil {

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -177,7 +177,10 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 
 	label := kcmdutil.GetFlagString(cmd, "labels")
 	if len(label) != 0 {
-		lbl := ctl.ParseLabels(label)
+		lbl, err := ctl.ParseLabels(label)
+		if err != nil {
+			return err
+		}
 		for key, value := range lbl {
 			templateObj.ObjectLabels[key] = value
 		}

--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -12,6 +12,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	kctl "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -84,7 +85,7 @@ func NewDeploymentConfigDescriber(client client.Interface, kclient kclient.Inter
 				return kclient.ReplicationControllers(namespace).Get(name)
 			},
 			listPodsFunc: func(namespace string, selector labels.Selector) (*kapi.PodList, error) {
-				return kclient.Pods(namespace).List(selector)
+				return kclient.Pods(namespace).List(selector, fields.Everything())
 			},
 			listEventsFunc: func(deploymentConfig *deployapi.DeploymentConfig) (*kapi.EventList, error) {
 				return kclient.Events(deploymentConfig.Namespace).Search(deploymentConfig)
@@ -266,7 +267,7 @@ func NewLatestDeploymentDescriber(client client.Interface, kclient kclient.Inter
 				return kclient.ReplicationControllers(namespace).Get(name)
 			},
 			listPodsFunc: func(namespace string, selector labels.Selector) (*kapi.PodList, error) {
-				return kclient.Pods(namespace).List(selector)
+				return kclient.Pods(namespace).List(selector, fields.Everything())
 			},
 			listEventsFunc: func(deploymentConfig *deployapi.DeploymentConfig) (*kapi.EventList, error) {
 				return kclient.Events(deploymentConfig.Namespace).Search(deploymentConfig)

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -1,7 +1,6 @@
 package describe
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 	"sort"
@@ -699,14 +698,10 @@ const policyRuleHeadings = "Verbs\tResources\tResource Names\tExtension"
 
 func describePolicyRule(out *tabwriter.Writer, rule authorizationapi.PolicyRule, indent string) {
 	extensionString := ""
-	if rule.AttributeRestrictions != (runtime.EmbeddedObject{}) {
-		extensionString = fmt.Sprintf("%#v", rule.AttributeRestrictions.Object)
 
-		buffer := new(bytes.Buffer)
-		printer := NewHumanReadablePrinter(true)
-		if err := printer.PrintObj(rule.AttributeRestrictions.Object, buffer); err == nil {
-			extensionString = strings.TrimSpace(buffer.String())
-		}
+	switch restrict := rule.AttributeRestrictions; {
+	case restrict.IsPersonalSubjectAccessReview:
+		extensionString = fmt.Sprintf("personal access review")
 	}
 
 	fmt.Fprintf(out, indent+"%v\t%v\t%v\t%v\n",

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -47,9 +47,6 @@ var (
 	userColumns                = []string{"NAME", "UID", "FULL NAME", "IDENTITIES"}
 	identityColumns            = []string{"NAME", "IDP NAME", "IDP USER NAME", "USER NAME", "USER UID"}
 	userIdentityMappingColumns = []string{"NAME", "IDENTITY", "USER NAME", "USER UID"}
-
-	// known custom role extensions
-	IsPersonalSubjectAccessReviewColumns = []string{"NAME"}
 )
 
 var (
@@ -115,8 +112,6 @@ func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p.Handler(identityColumns, printIdentity)
 	p.Handler(identityColumns, printIdentityList)
 	p.Handler(userIdentityMappingColumns, printUserIdentityMapping)
-
-	p.Handler(IsPersonalSubjectAccessReviewColumns, printIsPersonalSubjectAccessReview)
 	return p
 }
 
@@ -438,11 +433,6 @@ func printClusterRoleBinding(roleBinding *authorizationapi.ClusterRoleBinding, w
 
 func printClusterRoleBindingList(list *authorizationapi.ClusterRoleBindingList, w io.Writer) error {
 	return printRoleBindingList(authorizationTypeConverter.ToRoleBindingList(list), w)
-}
-
-func printIsPersonalSubjectAccessReview(a *authorizationapi.IsPersonalSubjectAccessReview, w io.Writer) error {
-	_, err := fmt.Fprintf(w, "IsPersonalSubjectAccessReview\n")
-	return err
 }
 
 func printRole(role *authorizationapi.Role, w io.Writer) error {

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -101,7 +101,7 @@ func (o OverwriteBootstrapPolicyOptions) OverwriteBootstrapPolicy() error {
 	if err != nil {
 		return err
 	}
-	etcdHelper, err := newEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion)
+	etcdHelper, err := newEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
 	if err != nil {
 		return err
 	}
@@ -182,10 +182,10 @@ func OverwriteBootstrapPolicy(etcdHelper tools.EtcdHelper, masterNamespace, poli
 }
 
 // newEtcdHelper returns an EtcdHelper for the provided storage version.
-func newEtcdHelper(client *etcdclient.Client, version string) (oshelper tools.EtcdHelper, err error) {
+func newEtcdHelper(client *etcdclient.Client, version, prefix string) (oshelper tools.EtcdHelper, err error) {
 	interfaces, err := latest.InterfacesFor(version)
 	if err != nil {
 		return tools.EtcdHelper{}, err
 	}
-	return tools.NewEtcdHelper(client, interfaces.Codec), nil
+	return tools.NewEtcdHelper(client, interfaces.Codec, prefix), nil
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -2,7 +2,6 @@ package bootstrappolicy
 
 import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -104,7 +103,7 @@ func GetBootstrapMasterRoles(masterNamespace string) []authorizationapi.Role {
 				{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("users"), ResourceNames: util.NewStringSet("~")},
 				{Verbs: util.NewStringSet("list"), Resources: util.NewStringSet("projectrequests")},
 				{Verbs: util.NewStringSet("list"), Resources: util.NewStringSet("projects")},
-				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("subjectaccessreviews"), AttributeRestrictions: runtime.EmbeddedObject{&authorizationapi.IsPersonalSubjectAccessReview{}}},
+				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("subjectaccessreviews"), AttributeRestrictions: authorizationapi.AttributeRestrictions{IsPersonalSubjectAccessReview: true}},
 			},
 		},
 		{

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -82,22 +82,22 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 }
 
 func (c *MasterConfig) RunNamespaceController() {
-	namespaceController := namespace.NewNamespaceManager(c.KubeClient)
-	namespaceController.Run(1 * time.Minute)
+	namespaceController := namespace.NewNamespaceManager(c.KubeClient, 5*time.Minute)
+	namespaceController.Run()
 	glog.Infof("Started Kubernetes Namespace Manager")
 }
 
 // RunReplicationController starts the Kubernetes replication controller sync loop
 func (c *MasterConfig) RunReplicationController() {
 	controllerManager := controller.NewReplicationManager(c.KubeClient)
-	controllerManager.Run(10 * time.Second)
+	controllerManager.Run(5, util.NeverStop)
 	glog.Infof("Started Kubernetes Replication Manager")
 }
 
 // RunEndpointController starts the Kubernetes replication controller sync loop
 func (c *MasterConfig) RunEndpointController() {
 	endpoints := service.NewEndpointController(c.KubeClient)
-	go util.Forever(func() { endpoints.SyncServiceEndpoints() }, time.Second*10)
+	endpoints.Run(5, util.NeverStop)
 
 	glog.Infof("Started Kubernetes Endpoint Controller")
 }
@@ -130,14 +130,9 @@ func (c *MasterConfig) RunMinionController() {
 		},
 	}
 
-	kubeletClient, err := kclient.NewKubeletClient(c.KubeletClientConfig)
-	if err != nil {
-		glog.Fatalf("Failure to create kubelet client: %v", err)
-	}
-
 	minionController := minioncontroller.NewNodeController(
 		nil, "", c.NodeHosts, nodeResources,
-		c.KubeClient, kubeletClient,
+		c.KubeClient,
 		10,            // registerRetryCount
 		5*time.Minute, // podEvictionTimeout
 
@@ -146,6 +141,7 @@ func (c *MasterConfig) RunMinionController() {
 		40*time.Second, // monitor grace
 		1*time.Minute,  // startup grace
 		10*time.Second, // monitor period
+		"openshift",
 	)
 	minionController.Run(10*time.Second, true)
 

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -90,14 +90,14 @@ func (c *MasterConfig) RunNamespaceController() {
 // RunReplicationController starts the Kubernetes replication controller sync loop
 func (c *MasterConfig) RunReplicationController() {
 	controllerManager := controller.NewReplicationManager(c.KubeClient)
-	controllerManager.Run(5, util.NeverStop)
+	go controllerManager.Run(5, util.NeverStop)
 	glog.Infof("Started Kubernetes Replication Manager")
 }
 
 // RunEndpointController starts the Kubernetes replication controller sync loop
 func (c *MasterConfig) RunEndpointController() {
 	endpoints := service.NewEndpointController(c.KubeClient)
-	endpoints.Run(5, util.NeverStop)
+	go endpoints.Run(5, util.NeverStop)
 
 	glog.Infof("Started Kubernetes Endpoint Controller")
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -48,7 +48,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	if err != nil {
 		return nil, err
 	}
-	ketcdHelper, err := master.NewEtcdHelper(etcdClient, options.EtcdStorageConfig.KubernetesStorageVersion)
+	ketcdHelper, err := master.NewEtcdHelper(etcdClient, options.EtcdStorageConfig.KubernetesStorageVersion, "kubernetes.io")
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up Kubernetes server storage: %v", err)
 	}

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -95,7 +95,7 @@ func (c *NodeConfig) HandleDockerError(message string) {
 		glog.Fatalf("ERROR: %s", message)
 	}
 	glog.Errorf("WARNING: %s", message)
-	c.DockerClient = &dockertools.FakeDockerClient{VersionInfo: dockerclient.Env{"apiversion=1.15"}}
+	c.DockerClient = &dockertools.FakeDockerClient{VersionInfo: dockerclient.Env{"ApiVersion=1.18"}}
 }
 
 // EnsureVolumeDir attempts to convert the provided volume directory argument to

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -12,16 +12,19 @@ import (
 	"time"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/cadvisor"
 	kconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
+	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/proxy"
 	pconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	kexec "github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/iptables"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
 	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 
@@ -155,7 +158,7 @@ func (c *NodeConfig) RunKubelet() {
 	// initialize Kubelet
 	// Allow privileged containers
 	// TODO: make this configurable and not the default https://github.com/openshift/origin/issues/662
-	kubelet.SetupCapabilities(true, hostNetworkCapabilities)
+	capabilities.Setup(true, hostNetworkCapabilities)
 	recorder := record.NewBroadcaster().NewRecorder(kapi.EventSource{Component: "kubelet", Host: c.NodeHost})
 
 	cfg := kconfig.NewPodConfig(kconfig.PodConfigNotificationSnapshotAndUpdates, recorder)
@@ -206,6 +209,11 @@ func (c *NodeConfig) RunKubelet() {
 		imageGCPolicy,
 		nil,
 		15*time.Second,
+		"/kubelet",
+		kubecontainer.RealOS{},
+		"",
+		"docker",
+		mount.New(),
 	)
 	if err != nil {
 		glog.Fatalf("Couldn't run kubelet: %s", err)

--- a/pkg/cmd/server/origin/auth_config.go
+++ b/pkg/cmd/server/origin/auth_config.go
@@ -38,7 +38,7 @@ func BuildAuthConfig(options configapi.MasterConfig) (*AuthConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion)
+	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up server storage: %v", err)
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -97,7 +97,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion)
+	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up server storage: %v", err)
 	}
@@ -314,10 +314,10 @@ func (c *MasterConfig) OriginNamespaceControllerClients() (*osclient.Client, *kc
 }
 
 // NewEtcdHelper returns an EtcdHelper for the provided storage version.
-func NewEtcdHelper(client *etcdclient.Client, version string) (oshelper tools.EtcdHelper, err error) {
+func NewEtcdHelper(client *etcdclient.Client, version, prefix string) (oshelper tools.EtcdHelper, err error) {
 	interfaces, err := latest.InterfacesFor(version)
 	if err != nil {
 		return tools.EtcdHelper{}, err
 	}
-	return tools.NewEtcdHelper(client, interfaces.Codec), nil
+	return tools.NewEtcdHelper(client, interfaces.Codec, prefix), nil
 }

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -62,7 +62,7 @@ func (factory *DeploymentControllerFactory) Create() controller.RunnableControll
 				return factory.KubeClient.Pods(namespace).Create(pod)
 			},
 			deletePodFunc: func(namespace, name string) error {
-				return factory.KubeClient.Pods(namespace).Delete(name)
+				return factory.KubeClient.Pods(namespace).Delete(name, nil)
 			},
 		},
 		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {

--- a/pkg/deploy/registry/etcd/etcd_test.go
+++ b/pkg/deploy/registry/etcd/etcd_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/deploy/api"
@@ -54,7 +55,7 @@ func makeTestDefaultDeploymentConfigListKey() string {
 }
 
 func NewTestEtcd(client tools.EtcdClient) *Etcd {
-	return New(tools.NewEtcdHelper(client, latest.Codec))
+	return New(tools.NewEtcdHelper(client, latest.Codec, etcdtest.PathPrefix()))
 }
 
 func TestEtcdListEmptyDeployments(t *testing.T) {

--- a/pkg/image/registry/image/etcd/etcd_test.go
+++ b/pkg/image/registry/image/etcd/etcd_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/coreos/go-etcd/etcd"
@@ -60,7 +61,7 @@ func makeTestDefaultImageRepositoriesListKey() string {
 func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	return fakeEtcdClient, helper
 }
 

--- a/pkg/image/registry/imagerepository/rest_test.go
+++ b/pkg/image/registry/imagerepository/rest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/coreos/go-etcd/etcd"
 
@@ -54,7 +55,7 @@ func (u *fakeUser) GetGroups() []string {
 func newTestHelpers(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST, *StatusREST) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	imageStreamStorage, imageStreamStatusStorage := imagestreametcd.NewREST(helper, testDefaultRegistry, &fakeSubjectAccessReviewRegistry{})
 	imageStreamRegistry := imagestream.NewRegistry(imageStreamStorage, imageStreamStatusStorage)
 	storage, statusStorage := NewREST(imageStreamRegistry)

--- a/pkg/image/registry/imagerepositorymapping/rest_test.go
+++ b/pkg/image/registry/imagerepositorymapping/rest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -37,7 +38,7 @@ func (f *fakeSubjectAccessReviewRegistry) CreateSubjectAccessReview(ctx kapi.Con
 func setup(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	imageStorage := imageetcd.NewREST(helper)
 	imageRegistry := image.NewRegistry(imageStorage)
 	imageStreamStorage, imageStreamStatus := imagestreametcd.NewREST(helper, testDefaultRegistry, &fakeSubjectAccessReviewRegistry{})

--- a/pkg/image/registry/imagerepositorytag/rest_test.go
+++ b/pkg/image/registry/imagerepositorytag/rest_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -53,7 +54,7 @@ func (u *fakeUser) GetGroups() []string {
 func setup(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	imageStorage := imageetcd.NewREST(helper)
 	imageRegistry := image.NewRegistry(imageStorage)
 	imageStreamStorage, imageStreamStatus := imagestreametcd.NewREST(helper, testDefaultRegistry, &fakeSubjectAccessReviewRegistry{})

--- a/pkg/image/registry/imagestream/etcd/etcd_test.go
+++ b/pkg/image/registry/imagestream/etcd/etcd_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/openshift/origin/pkg/api/latest"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -43,7 +44,7 @@ func (f *fakeSubjectAccessReviewRegistry) CreateSubjectAccessReview(ctx kapi.Con
 func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	return fakeEtcdClient, helper
 }
 

--- a/pkg/image/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/registry/imagestreamimage/rest_test.go
@@ -4,6 +4,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/openshift/origin/pkg/api/latest"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -30,7 +31,7 @@ func (f *fakeSubjectAccessReviewRegistry) CreateSubjectAccessReview(ctx kapi.Con
 func setup(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	imageStorage := imageetcd.NewREST(helper)
 	imageRegistry := image.NewRegistry(imageStorage)
 	imageStreamStorage, imageStreamStatus := imagestreametcd.NewREST(helper, testDefaultRegistry, &fakeSubjectAccessReviewRegistry{})

--- a/pkg/image/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/registry/imagestreammapping/rest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -36,7 +37,7 @@ func (f *fakeSubjectAccessReviewRegistry) CreateSubjectAccessReview(ctx kapi.Con
 func setup(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	imageStorage := imageetcd.NewREST(helper)
 	imageRegistry := image.NewRegistry(imageStorage)
 	imageStreamStorage, imageStreamStatus := imagestreametcd.NewREST(helper, testDefaultRegistry, &fakeSubjectAccessReviewRegistry{})

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/coreos/go-etcd/etcd"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -52,7 +53,7 @@ func (u *fakeUser) GetGroups() []string {
 func setup(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	imageStorage := imageetcd.NewREST(helper)
 	imageRegistry := image.NewRegistry(imageStorage)
 	imageStreamStorage, imageStreamStatus := imagestreametcd.NewREST(helper, testDefaultRegistry, &fakeSubjectAccessReviewRegistry{})

--- a/pkg/project/admission/admission_test.go
+++ b/pkg/project/admission/admission_test.go
@@ -42,7 +42,7 @@ func TestAdmissionExists(t *testing.T) {
 		},
 		Status: buildapi.BuildStatusNew,
 	}
-	err := handler.Admit(admission.NewAttributesRecord(build, "bogus-ns", "builds", "CREATE"))
+	err := handler.Admit(admission.NewAttributesRecord(build, "Build", "bogus-ns", "builds", "CREATE"))
 	if err == nil {
 		t.Errorf("Expected an error because namespace does not exist")
 	}
@@ -86,7 +86,7 @@ func TestAdmissionLifecycle(t *testing.T) {
 		},
 		Status: buildapi.BuildStatusNew,
 	}
-	err := handler.Admit(admission.NewAttributesRecord(build, namespaceObj.Namespace, "builds", "CREATE"))
+	err := handler.Admit(admission.NewAttributesRecord(build, "Build", namespaceObj.Namespace, "builds", "CREATE"))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
@@ -96,19 +96,19 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store.Add(namespaceObj)
 
 	// verify create operations in the namespace cause an error
-	err = handler.Admit(admission.NewAttributesRecord(build, namespaceObj.Namespace, "builds", "CREATE"))
+	err = handler.Admit(admission.NewAttributesRecord(build, "Build", namespaceObj.Namespace, "builds", "CREATE"))
 	if err == nil {
 		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
 	}
 
 	// verify update operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(build, namespaceObj.Namespace, "builds", "UPDATE"))
+	err = handler.Admit(admission.NewAttributesRecord(build, "Build", namespaceObj.Namespace, "builds", "UPDATE"))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
 
 	// verify delete operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, namespaceObj.Namespace, "builds", "DELETE"))
+	err = handler.Admit(admission.NewAttributesRecord(nil, "Build", namespaceObj.Namespace, "builds", "DELETE"))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}

--- a/pkg/route/registry/etcd/etcd.go
+++ b/pkg/route/registry/etcd/etcd.go
@@ -117,7 +117,7 @@ func (registry *Etcd) WatchRoutes(ctx kapi.Context, label labels.Selector, field
 		if err != nil {
 			return nil, err
 		}
-		return registry.Watch(key, version), nil
+		return registry.Watch(key, version, tools.Everything)
 	}
 
 	if field.Empty() {

--- a/pkg/route/registry/etcd/etcd_test.go
+++ b/pkg/route/registry/etcd/etcd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/coreos/go-etcd/etcd"
 
@@ -40,7 +41,7 @@ func makeTestDefaultRouteListKey() string {
 }
 
 func NewTestEtcd(client tools.EtcdClient) *Etcd {
-	return New(tools.NewEtcdHelper(client, latest.Codec))
+	return New(tools.NewEtcdHelper(client, latest.Codec, etcdtest.PathPrefix()))
 }
 
 func TestEtcdListEmptyRoutes(t *testing.T) {

--- a/pkg/template/registry/etcd/etcd_test.go
+++ b/pkg/template/registry/etcd/etcd_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest/resttest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/template/api"
@@ -15,7 +16,7 @@ import (
 func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
 	fakeEtcdClient := tools.NewFakeEtcdClient(t)
 	fakeEtcdClient.TestIndex = true
-	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec)
+	helper := tools.NewEtcdHelper(fakeEtcdClient, latest.Codec, etcdtest.PathPrefix())
 	return fakeEtcdClient, helper
 }
 

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -12,6 +12,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/auth/authenticator/request/headerrequest"
@@ -54,7 +55,7 @@ func TestFrontProxyOnAuthorize(t *testing.T) {
 
 	// setup
 	etcdClient := testutil.NewEtcdClient()
-	etcdHelper, _ := master.NewEtcdHelper(etcdClient, latest.Version)
+	etcdHelper, _ := master.NewEtcdHelper(etcdClient, latest.Version, etcdtest.PathPrefix())
 
 	accessTokenStorage := accesstokenetcd.NewREST(etcdHelper)
 	accessTokenRegistry := accesstokenregistry.NewRegistry(accessTokenStorage)

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -100,7 +100,7 @@ func TestOverwritePolicyCommand(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion)
+	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -178,7 +179,7 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 	openshift.lock.Lock()
 	defer openshift.lock.Unlock()
 	etcdClient := testutil.NewEtcdClient()
-	etcdHelper, _ := master.NewEtcdHelper(etcdClient, latest.Version)
+	etcdHelper, _ := master.NewEtcdHelper(etcdClient, latest.Version, etcdtest.PathPrefix())
 
 	osMux := http.NewServeMux()
 	openshift.server = httptest.NewServer(osMux)

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -13,6 +13,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 
 	// for osinserver setup.
 	"github.com/openshift/origin/pkg/api/latest"
@@ -52,7 +53,7 @@ func TestGetToken(t *testing.T) {
 
 	// setup
 	etcdClient := testutil.NewEtcdClient()
-	etcdHelper, _ := master.NewEtcdHelper(etcdClient, latest.Version)
+	etcdHelper, _ := master.NewEtcdHelper(etcdClient, latest.Version, etcdtest.PathPrefix())
 
 	accessTokenStorage := accesstokenetcd.NewREST(etcdHelper)
 	accessTokenRegistry := accesstokenregistry.NewRegistry(accessTokenStorage)

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -9,6 +9,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/RangelReale/osin"
 	"github.com/RangelReale/osincli"
 	"golang.org/x/oauth2"
@@ -60,7 +61,7 @@ func TestOAuthStorage(t *testing.T) {
 	testutil.DeleteAllEtcdKeys()
 	interfaces, _ := latest.InterfacesFor(latest.Version)
 	etcdClient := testutil.NewEtcdClient()
-	etcdHelper := tools.NewEtcdHelper(etcdClient, interfaces.Codec)
+	etcdHelper := tools.NewEtcdHelper(etcdClient, interfaces.Codec, etcdtest.PathPrefix())
 
 	accessTokenStorage := accesstokenetcd.NewREST(etcdHelper)
 	accessTokenRegistry := accesstokenregistry.NewRegistry(accessTokenStorage)

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -15,6 +15,7 @@ import (
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	namespaceetcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/namespace/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcdtest"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -34,7 +35,7 @@ func init() {
 func TestProjectIsNamespace(t *testing.T) {
 	testutil.DeleteAllEtcdKeys()
 	etcdClient := testutil.NewEtcdClient()
-	etcdHelper, err := master.NewEtcdHelper(etcdClient, "")
+	etcdHelper, err := master.NewEtcdHelper(etcdClient, "", etcdtest.PathPrefix())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -84,7 +84,7 @@ func TestUserInitialization(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion)
+	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/util/verify.go
+++ b/test/util/verify.go
@@ -138,6 +138,6 @@ func CleanupServiceAndPod(pod *kapi.Pod, service *kapi.Service, ns string) {
 	if err != nil {
 		return
 	}
-	client.Pods(ns).Delete(pod.Name)
+	client.Pods(ns).Delete(pod.Name, nil)
 	client.Services(ns).Delete(service.Name)
 }


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/kubernetes/pull/7116 changed the
pod output to display container status on individual lines.