### PR TITLE
[RPMS] bump BuildRequires: golang to 1.6.2

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -18,6 +18,7 @@
 # this is the version we obsolete up to. The packaging changed for Origin
 # 1.0.6 and OSE 3.1 such that 'openshift' package names were no longer used.
 %global package_refector_version 3.0.2.900
+%global golang_version 1.4.2
 # %commit and %ldflags are intended to be set by tito custom builders provided
 # in the .tito/lib directory. The values in this spec file will not be kept up to date.
 %{!?commit:
@@ -54,7 +55,7 @@ URL:            https://%{import_path}
 ExclusiveArch:  x86_64
 Source0:        https://%{import_path}/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildRequires:  systemd
-BuildRequires:  golang >= 1.4
+BuildRequires:  golang = %{golang_version}
 Requires:       %{name}-clients = %{version}-%{release}
 Requires:       iptables
 Obsoletes:      openshift < %{package_refector_version}
@@ -130,8 +131,8 @@ Requires:       git
 %if 0%{?make_redistributable}
 %package clients-redistributable
 Summary:        %{product_name} Client binaries for Linux, Mac OSX, and Windows
-BuildRequires:  golang-pkg-darwin-amd64
-BuildRequires:  golang-pkg-windows-386
+BuildRequires:  golang-pkg-darwin-amd64 = %{golang_version}
+BuildRequires:  golang-pkg-windows-386 = %{golang_version}
 Obsoletes:      openshift-clients-redistributable < %{package_refector_version}
 
 %description clients-redistributable

--- a/origin.spec
+++ b/origin.spec
@@ -18,7 +18,7 @@
 # this is the version we obsolete up to. The packaging changed for Origin
 # 1.0.6 and OSE 3.1 such that 'openshift' package names were no longer used.
 %global package_refector_version 3.0.2.900
-%global golang_version 1.4.2
+%global golang_version 1.6.2
 # %commit and %ldflags are intended to be set by tito custom builders provided
 # in the .tito/lib directory. The values in this spec file will not be kept up to date.
 %{!?commit:
@@ -131,8 +131,6 @@ Requires:       git
 %if 0%{?make_redistributable}
 %package clients-redistributable
 Summary:        %{product_name} Client binaries for Linux, Mac OSX, and Windows
-BuildRequires:  golang-pkg-darwin-amd64 = %{golang_version}
-BuildRequires:  golang-pkg-windows-386 = %{golang_version}
 Obsoletes:      openshift-clients-redistributable < %{package_refector_version}
 
 %description clients-redistributable


### PR DESCRIPTION
Done as two commits, the first can be cherry-picked into OSE 3.2, 3.1, and 3.0 branches in order to pin them to 1.4.2. The second actually updates to 1.6.2.
