### PR TITLE
prefix all metrics with "prometheus"

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -60,13 +60,13 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				metrics, err = p.TextToMetricFamilies(bytes.NewBufferString(results))
 				o.Expect(err).NotTo(o.HaveOccurred())
 				// original field in 2.0.0-beta
-				counts := findCountersWithLabels(metrics["tsdb_samples_appended_total"], labels{})
+				counts := findCountersWithLabels(metrics["prometheus_tsdb_samples_appended_total"], labels{})
 				if len(counts) != 0 && counts[0] > 0 {
 					success = true
 					break
 				}
 				// 2.0.0-rc.0
-				counts = findCountersWithLabels(metrics["tsdb_head_samples_appended_total"], labels{})
+				counts = findCountersWithLabels(metrics["prometheus_tsdb_head_samples_appended_total"], labels{})
 				if len(counts) != 0 && counts[0] > 0 {
 					success = true
 					break


### PR DESCRIPTION
see https://github.com/prometheus/tsdb/commit/d17104f1f04773a76959bd3be775ce0b051070e8
Looks like this change happened in prometheus v2.0.0-rc.2